### PR TITLE
yarn install 报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "vue-cropperjs": "^5.0.0",
     "vue-i18n": "^9.1.9",
     "vue-infinite-scroll": "^2.0.2",
-    "vue-print-nb-jeecg": "^1.0.10",
+    "vue-print-nb-jeecg": "^1.0.11",
     "vue-router": "^4.0.12",
     "vue-types": "^4.1.1",
     "vxe-table": "4.1.0",


### PR DESCRIPTION
vue-print-nb-jeecg改为最新的：^1.0.11