### PR TITLE
解决 在线报表开发中，vue3 动态参数不生效，且少一次网络请求的问题

### DIFF
--- a/src/components/jeecg/OnLine/hooks/usePopBiz.ts
+++ b/src/components/jeecg/OnLine/hooks/usePopBiz.ts
@@ -5,7 +5,7 @@ import { filterMultiDictText } from '/@/utils/dict/JDictSelectUtil.js';
 import { useMessage } from '/@/hooks/web/useMessage';
 import { OnlineColumn } from '/@/components/jeecg/OnLine/types/onlineConfig';
 import { h } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRouter, useRoute } from 'vue-router';
 import { useMethods } from '/@/hooks/system/useMethods';
 import { importViewsFile } from '/@/utils';
 
@@ -405,6 +405,7 @@ export function usePopBiz(props, tableRef?) {
 
   // 获取路由器对象 href跳转用到
   let router = useRouter();
+  let route = useRoute();
   /**
    * href 点击事件
    * @param field
@@ -512,6 +513,7 @@ export function usePopBiz(props, tableRef?) {
         //查询条件加载后再请求数据
         if (data) {
           setDataSource(data);
+          loadData(1);
         } else {
           //没有传递data时查询数据
           loadData(1);
@@ -531,6 +533,7 @@ export function usePopBiz(props, tableRef?) {
       pagination.current = 1;
     }
     let params = getQueryParams(); //查询条件
+    console.log('params', params);
     loading.value = true;
     let url = `${configUrl.getData}${unref(cgRpConfigId)}`;
     //缓存key
@@ -598,6 +601,8 @@ export function usePopBiz(props, tableRef?) {
       queryParam.value = { ...queryTemp };
     }
     let dynamicTemp = {};
+    props.param = { ...route.query };
+    // console.log('props', props);
     if (props.param) {
       Object.keys(props.param).map((key) => {
         let str = props.param[key];
@@ -611,7 +616,10 @@ export function usePopBiz(props, tableRef?) {
         dynamicTemp[key] = props.param[key];
       });
     }
+    // dynamicTemp['name'] = '小红帽4——prod';
     dynamicParam.value = { ...dynamicTemp };
+    console.log('dynamicTemp', dynamicTemp);
+    console.log('dynamicParam', dynamicParam.value);
   }
 
   /**


### PR DESCRIPTION
online报表配置中， 通过配置动态参数时，点击连接并不能很好的展示连接相关的报表内容。
经过分析，在获取href参数时没有成功获取到动态参数，并且相比vue2 少一次报表参数的网络请求，因此不能展示相关报表内容。

本次拉取请求，添加了获取href中参数的内容，同时补上了带有动态参数的网络请求。
