### PR TITLE
feat: 单选按钮组，支持图标icon的扩展，label改为可选

### DIFF
--- a/src/components/Form/src/components/RadioButtonGroup.vue
+++ b/src/components/Form/src/components/RadioButtonGroup.vue
@@ -5,7 +5,8 @@
   <RadioGroup v-bind="attrs" v-model:value="state" button-style="solid">
     <template v-for="item in getOptions" :key="`${item.value}`">
       <RadioButton :value="item.value" :disabled="item.disabled">
-        {{ item.label }}
+        <Icon v-if="item.icon" :icon="item.icon" />
+        {{ item.label ? item.label : '' }}
       </RadioButton>
     </template>
   </RadioGroup>
@@ -16,8 +17,13 @@
   import { isString } from '/@/utils/is';
   import { useRuleFormItem } from '/@/hooks/component/useFormItem';
   import { useAttrs } from '/@/hooks/core/useAttrs';
-
-  type OptionsItem = { label: string; value: string | number | boolean; disabled?: boolean };
+  import { Icon } from '/@/components/Icon';
+  type OptionsItem = {
+    icon?: string;
+    label?: string;
+    value: string | number | boolean;
+    disabled?: boolean;
+  };
   type RadioItem = string | OptionsItem;
 
   export default defineComponent({
@@ -25,6 +31,7 @@
     components: {
       RadioGroup: Radio.Group,
       RadioButton: Radio.Button,
+      Icon,
     },
     props: {
       value: {


### PR DESCRIPTION
表单里面单选字段只需要图标显示
```js
 {
    field: 'type',
    label: '对象类别图标',
    component: 'RadioButtonGroup',
    defaultValue: '0',
    componentProps: {
      options: [
        { icon: 'gg:loadbar-doc', value: '0' },
        { icon: 'gg:loadbar-alt', value: '1' },
        { icon: 'gg:loadbar-file', value: '2' },
      ],
    },
    colProps: { lg: 24, md: 24 },
  },
```
<img width="285" alt="image" src="https://user-images.githubusercontent.com/20919577/201670171-65cf4985-4bee-4cc1-9f75-a14d81b28fa3.png">
